### PR TITLE
Switch to long-lived access tokens for Home Assistant authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Syslog for Obihai phone device
 
     home-assistant section has the details of your running Home Assistant to send the device tracking information.
         url: http://192.168.1.77:8123 # This is your Home Assistant URL/IP without slash (/) at the end
-        password: home # This is your Home Assistant password
+        token: xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx # This is your Home Assistant long-lived access token
         show_history: 10 # show how many last calls history in HA
         Home Assistant Entity Names:
             sensor.obihai_reboot_required

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@ syslog: # SYSLOG details
 
 home-assistant: # Home Assistant access details to send obihai information
     url: http://192.168.1.77:8123 # Home Assistant URL/IP, no slash (/) at the end
-    password: home # Home Assistant password
+    token: "my long-lived access token" # Home Assistant API token
     show_history: 10 # show how many last call history in HA
 
 obihai: # Obihai device details

--- a/obihai_helper.py
+++ b/obihai_helper.py
@@ -191,8 +191,7 @@ class ObihaiHelper:
     def update_ha_sensor(self, entity, state_str, attributes):
         self.print(self.log_level_debug, "ObihaiHelper:uhs(): enter")
         try:
-            base_url_post = self.config["home-assistant"]["url"] + "/api/states/" + entity + "?api_password=" + \
-                            self.config["home-assistant"]["password"]
+            base_url_post = self.config["home-assistant"]["url"] + "/api/states/" + entity
             # for safety reason don't print following debug information as it may contain sensitive information
             # for users who has public facing Home Assistant
             # self.print(self.log_level_debug, "ObihaiHelper:uhs(): url: " + base_url_post)
@@ -200,7 +199,8 @@ class ObihaiHelper:
             payload = {"state": state_str, "attributes": attributes}
             self.print(self.log_level_info, "ObihaiHelper:uhs(): payload: " + str(json.dumps(payload)))
 
-            response = post(base_url_post, data=json.dumps(payload))
+            auth = {"Authorization": "Bearer " + self.config["home-assistant"]["token"]}
+            response = post(base_url_post, data=json.dumps(payload), headers=auth)
             self.print(self.log_level_info, "ObihaiHelper:uhs(): response: " + str(response.text))
         except Exception as e:
             self.print(self.log_level_error, "ObihaiHelper:uhs():Exception:" + str(e))
@@ -209,13 +209,13 @@ class ObihaiHelper:
     def ha_service_notify(self, whom, message):
         self.print(self.log_level_debug, "ObihaiHelper:hsn(): enter")
         try:
-            base_url_post = self.config["home-assistant"]["url"] + "/api/services/" + whom + "?api_password=" + \
-                            self.config["home-assistant"]["password"]
+            base_url_post = self.config["home-assistant"]["url"] + "/api/services/" + whom
 
             payload = {"message": message}
             self.print(self.log_level_info, "ObihaiHelper:hsn(): payload: " + str(json.dumps(payload)))
 
-            response = post(base_url_post, data=json.dumps(payload))
+            auth = {"Authorization": "Bearer " + self.config["home-assistant"]["token"]}
+            response = post(base_url_post, data=json.dumps(payload), headers=auth)
             self.print(self.log_level_info, "ObihaiHelper:hsn(): response: " + str(response.text))
         except Exception as e:
             self.print(self.log_level_error, "ObihaiHelper:uhs():Exception:" + str(e))

--- a/obihai_helper.py
+++ b/obihai_helper.py
@@ -5,7 +5,7 @@ from collections import OrderedDict
 
 import yaml  # this needs package called PyYAML
 
-from requests import post
+from requests import get, post
 
 
 class ObihaiHelper:
@@ -260,8 +260,8 @@ class ObihaiHelper:
                 phone_number = phone_number.replace('-', '')
                 phone_number = phone_number.replace('+', '')
                 phone_number = phone_number.replace(' ', '')
-                base_url_post = base_url + phone_number + sid + token
-                response = post(base_url_post)
+                base_url = base_url + phone_number + sid + token
+                response = get(base_url)
                 self.print(self.log_level_info, "ObihaiHelper:gcnfo():requesting: " + phone_number)
                 self.print(self.log_level_info, "ObihaiHelper:gcnfo():response: " + response.text)
                 if response.status_code == 200:

--- a/obihai_helper.py
+++ b/obihai_helper.py
@@ -53,7 +53,10 @@ class ObihaiHelper:
         if item is not None:
             caller_name = item["Name"]
         else:
-            caller_name = self.get_caller_name_from_opencnam(caller_number)
+            if caller_number == "":
+                caller_name = "Private Caller"
+            else:
+                caller_name = self.get_caller_name_from_opencnam(caller_number)
             json_phone_book[caller_number] = {
                 "Name": caller_name,
                 "Port": port_str,


### PR DESCRIPTION
Shared-secret logins have been deprecated. The [new method](https://developers.home-assistant.io/docs/en/auth_api.html#making-authenticated-requests) is to generate individual 10-year access tokens.

This pull request rips out the old method and implements the new. You may or may not want to retain legacy support.